### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 
 **Empower your AI agents and research tools with seamless PubMed integration!**
 
+<a href="https://glama.ai/mcp/servers/@cyanheads/pubmed-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cyanheads/pubmed-mcp-server/badge" alt="PubMed Server MCP server" />
+</a>
+
 An MCP (Model Context Protocol) server providing comprehensive access to PubMed's biomedical literature database. Enables LLMs and AI agents to search, retrieve, analyze, and visualize scientific publications through NCBI's E-utilities API with advanced research workflow capabilities.
 
 Built on the [`cyanheads/mcp-ts-template`](https://github.com/cyanheads/mcp-ts-template), this server follows a modular architecture with robust error handling, logging, and security features.


### PR DESCRIPTION
This PR adds a badge for the [PubMed MCP Server](https://glama.ai/mcp/servers/@cyanheads/pubmed-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@cyanheads/pubmed-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cyanheads/pubmed-mcp-server/badge" alt="PubMed Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.