### PR TITLE
Update index.ts

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -10,6 +10,9 @@
 import dotenv from 'dotenv';
 import { z } from 'zod';
 
+import { isAbsolute, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import packageJson from '../../package.json' with { type: 'json' };
 import { JsonRpcErrorCode, McpError } from '../types-global/errors.js';
 
@@ -380,11 +383,11 @@ const parseConfig = () => {
           // Bundled (dist/index.js) is one level deep; source (src/config/index.ts) is two.
           // Detect bundle path to avoid overshooting the project root.
           const depth = import.meta.url.includes('/dist/') ? '..' : '../..';
-          const p = new URL(depth, import.meta.url).pathname;
-          const root = p.endsWith('/') ? p.slice(0, -1) : p;
+          const p = fileURLToPath(new URL(depth, import.meta.url));
+          const root = p.endsWith('/') || p.endsWith('\\') ? p.slice(0, -1) : p;
           const logsDir = rawConfig.logsPath ?? 'logs';
-          if (logsDir.startsWith('/')) return logsDir;
-          return `${root}/${logsDir}`;
+          if (isAbsolute(logsDir)) return logsDir;
+          return join(root, logsDir);
         })()
       : undefined,
     mcpServerName: env.MCP_SERVER_NAME ?? parsedPkg.name,


### PR DESCRIPTION
Resolve log path correctly on Windows.  Prevents the log from resolving as "C:\C:\..." [isAbsolute ](https://nodejs.org/api/path.html#pathisabsolutepath), [join](https://nodejs.org/api/path.html#pathjoinpaths) and [fileURLToPath](https://nodejs.org/api/path.html#pathjoinpaths) are cross compatible. 