### PR TITLE
feat: structured abstract extraction + Europe PMC search tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { createApp } from '@cyanheads/mcp-ts-core';
 import { researchPlanPrompt } from './mcp-server/prompts/definitions/research-plan.prompt.js';
 import { databaseInfoResource } from './mcp-server/resources/definitions/database-info.resource.js';
 import { convertIdsTool } from './mcp-server/tools/definitions/convert-ids.tool.js';
+import { europepmcSearchTool } from './mcp-server/tools/definitions/europepmc-search.tool.js';
 import { fetchArticlesTool } from './mcp-server/tools/definitions/fetch-articles.tool.js';
 import { fetchFulltextTool } from './mcp-server/tools/definitions/fetch-fulltext.tool.js';
 import { findRelatedTool } from './mcp-server/tools/definitions/find-related.tool.js';
@@ -22,6 +23,7 @@ import { initUnpaywallService } from './services/unpaywall/unpaywall-service.js'
 await createApp({
   tools: [
     searchArticlesTool,
+    europepmcSearchTool,
     fetchArticlesTool,
     fetchFulltextTool,
     formatCitationsTool,

--- a/src/mcp-server/tools/definitions/europepmc-search.tool.ts
+++ b/src/mcp-server/tools/definitions/europepmc-search.tool.ts
@@ -1,0 +1,120 @@
+/**
+ * @fileoverview Europe PMC search tool. Searches the Europe PMC database for
+ * biomedical articles. Supports cursor-based pagination, sort orders, and
+ * returns PMID, title, authors, journal, year, DOI, citation counts, and
+ * full-text availability flags.
+ * @module src/mcp-server/tools/definitions/europepmc-search.tool
+ */
+
+import { tool, z } from '@cyanheads/mcp-ts-core';
+import { search } from '@/services/europepmc/europepmc-service.js';
+import {
+  conceptMeta,
+  EDAM_DATABASE_SEARCH,
+  EDAM_PUBMED_ID,
+  SCHEMA_SCHOLARLY_ARTICLE,
+} from './_concepts.js';
+
+const EuropePmcPaperSchema = z
+  .object({
+    pmid: z.string().describe('PubMed ID'),
+    title: z.string().describe('Article title'),
+    authorString: z.string().describe('Formatted author string'),
+    journalTitle: z.string().describe('Journal title'),
+    pubYear: z.string().describe('Publication year'),
+    doi: z.string().describe('DOI'),
+    source: z.string().describe('Data source (e.g. MED, PMC)'),
+    hasFullText: z.string().describe('Full text availability (Y/N)'),
+    citedByCount: z.number().describe('Number of citations in Europe PMC'),
+  })
+  .describe('Europe PMC search result entry');
+
+export const europepmcSearchTool = tool('pubmed_europepmc_search', {
+  description:
+    'Search Europe PMC for biomedical articles. Complements PubMed with broader European open-access coverage, preprints, and citation counts. Supports cursor-based pagination for scrolling through large result sets.',
+  annotations: { readOnlyHint: true, openWorldHint: true },
+  _meta: conceptMeta([SCHEMA_SCHOLARLY_ARTICLE, EDAM_DATABASE_SEARCH, EDAM_PUBMED_ID]),
+  sourceUrl:
+    'https://github.com/cyanheads/pubmed-mcp-server/blob/main/src/mcp-server/tools/definitions/europepmc-search.tool.ts',
+
+  input: z.object({
+    query: z.string().min(1).describe('Europe PMC search query (supports full Europe PMC syntax)'),
+    pageSize: z.number().int().min(1).max(1000).default(25).describe('Results per page'),
+    cursorMark: z
+      .string()
+      .default('*')
+      .describe('Cursor for pagination. Use "*" for first page, then use returned nextCursorMark.'),
+    sort: z
+      .enum(['RELEVANCE', 'DATE', 'CITED'])
+      .default('RELEVANCE')
+      .describe('Sort order: RELEVANCE, DATE (newest first), or CITED (most cited first)'),
+  }),
+
+  output: z.object({
+    query: z.string().describe('Original query'),
+    totalHits: z.number().describe('Total matching articles'),
+    nextCursorMark: z.string().describe('Cursor for next page (empty when no more results)'),
+    pageSize: z.number().describe('Results per page'),
+    results: z.array(EuropePmcPaperSchema).describe('Search results'),
+    searchUrl: z.string().describe('Europe PMC search URL'),
+  }),
+
+  async handler(input, ctx) {
+    ctx.log.info('Executing pubmed_europepmc_search', { query: input.query });
+    const result = await search({
+      query: input.query,
+      pageSize: input.pageSize,
+      cursorMark: input.cursorMark,
+      sort: input.sort,
+      signal: ctx.signal,
+    });
+
+    const searchUrl = `https://europepmc.org/search?query=${encodeURIComponent(input.query)}`;
+
+    ctx.log.info('pubmed_europepmc_search completed', {
+      totalHits: result.totalHits,
+      returned: result.results.length,
+    });
+
+    return {
+      query: input.query,
+      totalHits: result.totalHits,
+      nextCursorMark: result.nextCursorMark,
+      pageSize: result.pageSize,
+      results: result.results,
+      searchUrl,
+    };
+  },
+
+  format: (result) => {
+    const lines = [
+      '## Europe PMC Search Results',
+      `**Query:** ${result.query}`,
+      `**Total Hits:** ${result.totalHits} | **Returned:** ${result.results.length} | **Page Size:** ${result.pageSize}`,
+      `**Search URL:** ${result.searchUrl}`,
+    ];
+
+    if (result.nextCursorMark && result.nextCursorMark !== '*') {
+      lines.push(`**Next Cursor:** \`${result.nextCursorMark}\` (use for next page)`);
+    }
+
+    if (result.results.length === 0) {
+      lines.push('\n> No results found. Try broadening the query or checking spelling.');
+    }
+
+    for (const r of result.results) {
+      lines.push(`\n### ${r.title}`);
+      lines.push(`**PMID:** ${r.pmid} | **Year:** ${r.pubYear} | **Cited by:** ${r.citedByCount}`);
+      if (r.authorString) lines.push(`**Authors:** ${r.authorString}`);
+      if (r.journalTitle) lines.push(`**Journal:** ${r.journalTitle}`);
+      if (r.doi) lines.push(`**DOI:** ${r.doi}`);
+      if (r.source) lines.push(`**Source:** ${r.source}`);
+      lines.push(
+        `**Full Text:** ${r.hasFullText === 'Y' ? 'Available in Europe PMC' : 'Not available'}`,
+      );
+      lines.push(`**Cited by:** ${r.citedByCount}`);
+    }
+
+    return [{ type: 'text', text: lines.join('\n') }];
+  },
+});

--- a/src/mcp-server/tools/definitions/fetch-articles.tool.ts
+++ b/src/mcp-server/tools/definitions/fetch-articles.tool.ts
@@ -81,6 +81,13 @@ const GrantSchema = z
   })
   .describe('Grant record');
 
+const StructuredAbstractSectionSchema = z
+  .object({
+    label: z.string().optional().describe('Section label (e.g. BACKGROUND, METHODS, RESULTS)'),
+    text: z.string().describe('Section text content'),
+  })
+  .describe('Structured abstract section');
+
 const ArticleDateSchema = z
   .object({
     dateType: z.string().optional().describe('Date type'),
@@ -106,6 +113,10 @@ const FetchedArticleSchema = z
     keywords: z.array(z.string()).optional().describe('Keywords'),
     meshTerms: z.array(MeshTermSchema).optional().describe('MeSH terms'),
     grantList: z.array(GrantSchema).optional().describe('Grant information'),
+    structuredAbstract: z
+      .array(StructuredAbstractSectionSchema)
+      .optional()
+      .describe('Structured abstract with labeled sections'),
     articleDates: z.array(ArticleDateSchema).optional().describe('Article dates'),
   })
   .describe('Parsed PubMed article');
@@ -133,6 +144,12 @@ export const fetchArticlesTool = tool('pubmed_fetch_articles', {
     pmids: z.array(pmidStringSchema).min(1).max(200).describe('PubMed IDs to fetch'),
     includeMesh: z.boolean().default(true).describe('Include MeSH terms'),
     includeGrants: z.boolean().default(false).describe('Include grant information'),
+    includeStructuredAbstract: z
+      .boolean()
+      .default(false)
+      .describe(
+        'Include structured abstract with labeled sections (BACKGROUND, METHODS, RESULTS, CONCLUSIONS)',
+      ),
   }),
 
   output: z.object({
@@ -168,6 +185,7 @@ export const fetchArticlesTool = tool('pubmed_fetch_articles', {
         const parsed = parseFullArticle(a, {
           includeMesh: input.includeMesh,
           includeGrants: input.includeGrants,
+          includeStructuredAbstract: input.includeStructuredAbstract,
         });
         return {
           ...parsed,
@@ -247,6 +265,13 @@ export const fetchArticlesTool = tool('pubmed_fetch_articles', {
       }
 
       if (a.abstractText) lines.push(`\n#### Abstract\n${a.abstractText}`);
+      if (a.structuredAbstract?.length) {
+        lines.push(`\n#### Structured Abstract`);
+        for (const sec of a.structuredAbstract) {
+          const label = sec.label ? `**${sec.label}:** ` : '';
+          lines.push(`${label}${sec.text}`);
+        }
+      }
       if (a.keywords?.length) lines.push(`\n**Keywords:** ${a.keywords.join(', ')}`);
       if (a.meshTerms?.length) {
         lines.push(`\n#### MeSH Terms`);

--- a/src/services/europepmc/europepmc-service.ts
+++ b/src/services/europepmc/europepmc-service.ts
@@ -1,0 +1,125 @@
+/**
+ * @fileoverview Europe PMC API service. Calls the Europe PMC REST API for
+ * article search and retrieval. No API key required (free public access).
+ * @module src/services/europepmc/europepmc-service
+ */
+
+const EUROPE_PMC_BASE = 'https://www.ebi.ac.uk/europepmc/webservices/rest';
+
+export interface EuropePmcPaper {
+  authorString: string;
+  citedByCount: number;
+  doi: string;
+  hasFullText: string;
+  journalTitle: string;
+  pmid: string;
+  pubYear: string;
+  source: string;
+  title: string;
+}
+
+export interface EuropePmcSearchResult {
+  nextCursorMark: string;
+  pageSize: number;
+  results: EuropePmcPaper[];
+  totalHits: number;
+}
+
+let _config: EuropePmcConfig | null = null;
+
+export interface EuropePmcConfig {
+  timeoutMs: number;
+}
+
+interface EuropePmcApiResponse {
+  nextCursorMark?: string;
+  resultList?: {
+    result?: Array<Record<string, unknown>>;
+    hitCount?: number | string;
+  };
+}
+
+const DefaultConfig: EuropePmcConfig = {
+  timeoutMs: 20000,
+};
+
+export function getEuropePmcConfig(): EuropePmcConfig {
+  if (!_config) {
+    _config = { ...DefaultConfig };
+  }
+  return _config;
+}
+
+/**
+ * Search Europe PMC with cursor-based pagination.
+ * @param query - Europe PMC query syntax
+ * @param pageSize - Results per page (1-1000)
+ * @param cursorMark - Cursor for pagination ("*" for first page)
+ * @param sort - Sort order: RELEVANCE, DATE, or CITED
+ * @param signal - Optional AbortSignal
+ */
+export async function search({
+  query,
+  pageSize = 25,
+  cursorMark = '*',
+  sort = 'RELEVANCE',
+  signal,
+}: {
+  query: string;
+  pageSize?: number;
+  cursorMark?: string;
+  sort?: string;
+  signal?: AbortSignal;
+}): Promise<EuropePmcSearchResult> {
+  const config = getEuropePmcConfig();
+  const params = new URLSearchParams({
+    query,
+    resultType: 'core',
+    pageSize: String(Math.min(Math.max(pageSize, 1), 1000)),
+    cursorMark,
+    sort,
+    format: 'json',
+  });
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), config.timeoutMs);
+  if (signal) {
+    signal.addEventListener('abort', () => controller.abort());
+  }
+
+  try {
+    const resp = await fetch(`${EUROPE_PMC_BASE}/search?${params}`, {
+      signal: controller.signal,
+      headers: { 'User-Agent': 'pubmed-mcp-server/2.6' },
+    });
+
+    if (!resp.ok) {
+      throw new Error(`Europe PMC API error: HTTP ${resp.status}`);
+    }
+
+    const data = (await resp.json()) as EuropePmcApiResponse;
+    const resultList = data?.resultList ?? {};
+
+    const rawResults: Array<Record<string, unknown>> = Array.isArray(resultList.result) ? resultList.result : [];
+    const results: EuropePmcPaper[] = rawResults.map((r) => ({
+      pmid: String(r.pmid ?? ''),
+      title: String(r.title ?? 'N/A'),
+      authorString: String(r.authorString ?? ''),
+      journalTitle: String(r.journalTitle ?? ''),
+      pubYear: String(r.pubYear ?? ''),
+      doi: String(r.doi ?? ''),
+      source: String(r.source ?? ''),
+      hasFullText: String(r.hasFullText ?? 'N'),
+      citedByCount: Number(r.citedByCount ?? 0),
+    }));
+
+    return {
+      totalHits: Number(resultList.hitCount ?? 0),
+      nextCursorMark: data.nextCursorMark ?? '',
+      pageSize,
+      results,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/src/services/ncbi/parsing/article-parser.ts
+++ b/src/services/ncbi/parsing/article-parser.ts
@@ -12,6 +12,7 @@ import type {
   ParsedJournalInfo,
   ParsedMeshQualifier,
   ParsedMeshTerm,
+  ParsedStructuredAbstractSection,
   ParseFullArticleOptions,
   XmlAbstractText,
   XmlArticle,
@@ -340,23 +341,49 @@ export function extractAbstractText(abstractXml?: XmlArticle['Abstract']): strin
 
   const processedTexts = abstractTexts
     .map((at: XmlAbstractText | string) => {
-      // AbstractText can be string directly or object
-      if (typeof at === 'string') {
-        return at;
-      }
-      // If it's an object, it should have #text or Label
-      const sectionText = getText(at); // Handles at['#text']
+      if (typeof at === 'string') return at;
+      const sectionText = getText(at);
       const label = getAttribute(at, 'Label');
-      if (label && sectionText) {
-        return `${label.trim()}: ${sectionText.trim()}`;
-      }
+      if (label && sectionText) return `${label.trim()}: ${sectionText.trim()}`;
       return sectionText.trim();
     })
-    .filter(Boolean); // Remove any empty strings resulting from empty sections
+    .filter(Boolean);
 
   if (processedTexts.length === 0) return;
+  return processedTexts.join('\n\n').trim() || undefined;
+}
 
-  return processedTexts.join('\n\n').trim() || undefined; // Join sections with double newline
+/**
+ * Extracts structured abstract sections from XML.
+ * Returns individual labeled sections (e.g. BACKGROUND, METHODS, RESULTS, CONCLUSIONS).
+ * Falls back to empty array for unstructured abstracts.
+ * @param abstractXml - The XML Abstract element from an Article.
+ * @returns Array of structured abstract sections, or undefined if no abstract exists.
+ */
+export function extractStructuredAbstract(
+  abstractXml?: XmlArticle['Abstract'],
+): ParsedStructuredAbstractSection[] | undefined {
+  if (!abstractXml?.AbstractText) return;
+
+  const abstractTexts = ensureArray(abstractXml.AbstractText);
+  if (abstractTexts.length === 0) return;
+
+  const sections = abstractTexts
+    .map((at: XmlAbstractText | string) => {
+      if (typeof at === 'string') {
+        return { text: at.trim() };
+      }
+      const sectionText = getText(at);
+      const label = getAttribute(at, 'Label');
+      if (!sectionText?.trim()) return null;
+      return {
+        ...(label?.trim() && { label: label.trim() }),
+        text: sectionText.trim(),
+      };
+    })
+    .filter((s): s is NonNullable<typeof s> => s !== null);
+
+  return sections.length > 0 ? sections : undefined;
 }
 
 /**
@@ -398,9 +425,12 @@ export function parseFullArticle(
 ): ParsedArticle {
   const medlineCitation = xmlArticle.MedlineCitation;
   const article = medlineCitation?.Article;
-  const { includeMesh = true, includeGrants = false } = options;
+  const { includeMesh = true, includeGrants = false, includeStructuredAbstract = false } = options;
 
   const abstractText = extractAbstractText(article?.Abstract);
+  const structuredAbstract = includeStructuredAbstract
+    ? extractStructuredAbstract(article?.Abstract)
+    : undefined;
   const journalInfo = extractJournalInfo(article?.Journal, article);
   const pubmedDataArticleIdList = xmlArticle.PubmedData?.ArticleIdList;
   const doi = extractDoi(article, pubmedDataArticleIdList);
@@ -424,6 +454,7 @@ export function parseFullArticle(
     ...(keywords.length > 0 && { keywords }),
     ...(meshTerms !== undefined && meshTerms.length > 0 && { meshTerms }),
     ...(grantList !== undefined && grantList.length > 0 && { grantList }),
+    ...(structuredAbstract !== undefined && { structuredAbstract }),
     ...(doi !== undefined && { doi }),
     ...(pmcId !== undefined && { pmcId }),
     ...(articleDates.length > 0 && { articleDates }),

--- a/src/services/ncbi/types.ts
+++ b/src/services/ncbi/types.ts
@@ -63,6 +63,7 @@ export interface NcbiCallOptions {
 export interface ParseFullArticleOptions {
   includeGrants?: boolean;
   includeMesh?: boolean;
+  includeStructuredAbstract?: boolean;
 }
 
 // ─── XML Element Types (PubMed DTD) ─────────────────────────────────────────
@@ -310,6 +311,11 @@ export interface ParsedGrant {
   grantId?: string;
 }
 
+export interface ParsedStructuredAbstractSection {
+  label?: string;
+  text: string;
+}
+
 export interface ParsedArticle {
   abstractText?: string;
   affiliations?: string[];
@@ -323,6 +329,7 @@ export interface ParsedArticle {
   pmcId?: string;
   pmid: string;
   publicationTypes?: string[];
+  structuredAbstract?: ParsedStructuredAbstractSection[];
   title?: string;
   // Add other fields as needed, e.g., language, publication status
 }


### PR DESCRIPTION
## Changes

### New: Structured Abstract Extraction
- `extractStructuredAbstract()` in `article-parser.ts` preserves labeled sections (BACKGROUND, METHODS, RESULTS, CONCLUSIONS) from PubMed XML
- `includeStructuredAbstract` parameter added to `pubmed_fetch_articles` tool
- `ParsedStructuredAbstractSection` type with label + text fields

### New: Europe PMC Search Tool
- `pubmed_europepmc_search` tool — cursor-based pagination, citation counts, full-text availability, sort orders (RELEVANCE/DATE/CITED)
- `EuropePmcService` — free API, no key required
- Registered as tool #10 in `createApp()`

### Fixes
- `ParsedStructuredAbstractSection` interface moved outside `ParsedArticle` (was accidentally nested)
- TypeScript compiles clean