### PR TITLE
fix: normalize bare numeric PMCID inputs before API call

### DIFF
--- a/src/services/ncbi/ncbi-service.ts
+++ b/src/services/ncbi/ncbi-service.ts
@@ -257,8 +257,13 @@ export class NcbiService {
     idtype?: string,
     options?: NcbiCallOptions,
   ): Promise<IdConvertRecord[]> {
+    // Normalize PMCID inputs: bare numeric IDs (e.g. "3531190") get "PMC" prefixed
+    // so mixed PMC-prefixed and bare IDs don't trigger a 400 from the converter.
+    const normalized = ids.map((id) =>
+      idtype === 'pmcid' && /^\d+$/.test(id) ? `PMC${id}` : id,
+    );
     const params: NcbiRequestParams = {
-      ids: ids.join(','),
+      ids: normalized.join(','),
       format: 'json',
       ...(idtype && { idtype }),
     };


### PR DESCRIPTION
Closes #73

When `idType: "pmcid"` is used, bare numeric IDs like `"3531190"` are now automatically prefixed with `PMC` before joining the batch. This prevents HTTP 400 errors when mixed with already-prefixed IDs like `"PMC3531190"`.

The fix is a focused normalization step before the existing `ids.join(',')` call — no other logic changed.

- Only applies when `idtype === "pmcid"`
- Only transforms IDs that are purely digits (regex: `^\d+$`)
- All other IDs pass through unchanged